### PR TITLE
fix: update socket.io because of EventEmitter deprecation (Node 7+)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,14 @@
     "url": "https://github.com/lorenwest"
   },
   "homepage": "http://lorenwest.github.com/node-monitor/",
-  "keywords": ["monitor", "node-monitor", "remote control", "realtime", "probe", "JMX"],
+  "keywords": [
+    "monitor",
+    "node-monitor",
+    "remote control",
+    "realtime",
+    "probe",
+    "JMX"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/lorenwest/node-monitor.git"
@@ -21,18 +28,20 @@
     }
   ],
   "dependencies": {
+    "backbone": "0.9.9",
+    "backbone-callbacks": ">=0.1.4 <0.2.0",
     "config": ">=0.4.34 <0.5.0",
     "cron": ">=0.1.3 <0.2.0",
-    "backbone": "0.9.9",
-    "underscore": ">=1.4.3 <1.5.0",
-    "backbone-callbacks": ">=0.1.4 <0.2.0",
-    "socket.io-client": ">=0.9.11 <0.10.0",
-    "socket.io": ">=0.9.10 <0.10.0"
+    "socket.io": "^1.5.1",
+    "socket.io-client": "^1.5.1",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "grunt": "0.3.17"
   },
-  "engines": { "node": ">= 0.6.0" },
+  "engines": {
+    "node": ">= 0.6.0"
+  },
   "scripts": {
     "test": "grunt test",
     "start": "node monitor"


### PR DESCRIPTION
To work on Node 7 and more, 
i update Socket.io dependency (and also underscore for the fun)

Related issue
#29 

On my environment, i can't launch tests, i have this error:
```
Loading "test.js" tasks and helpers...ERROR
>> Error: No such module: evals
<WARN> Task "test" not found. Use --force to continue. </WARN>

Aborted due to warnings.
```